### PR TITLE
Fix leader guide

### DIFF
--- a/autoload/spaceneovim.vim
+++ b/autoload/spaceneovim.vim
@@ -16,7 +16,7 @@ let g:spaceneovim_plugins = []
 " }}}
 
 " Set up configurable variables {{{
-let s:default_repository = 'https://github.com/Tehnix/spaceneovim-layers.git'
+let s:default_repository = 'https://github.com/lowski/spaceneovim-layers.git'
 let g:dotspaceneovim_layers_repository = get(g:, 'dotspaceneovim_layers_repository', s:default_repository)
 let g:dotspaceneovim_additional_plugins = get(g:, 'dotspaceneovim_additional_plugins', [])
 let g:dotspaceneovim_configuration_layers = get(g:, 'dotspaceneovim_configuration_layers', [])

--- a/autoload/spaceneovim.vim
+++ b/autoload/spaceneovim.vim
@@ -197,5 +197,8 @@ function! spaceneovim#bootstrap() abort
       \g:dotspaceneovim_additional_plugins
     \)
   endif
+
+  call g:Spaceneovim_postinstall()
+  
   call s:debug('>>> Finished SpaceNeovim bootstrap')
 endfunction

--- a/autoload/spaceneovim.vim
+++ b/autoload/spaceneovim.vim
@@ -16,7 +16,7 @@ let g:spaceneovim_plugins = []
 " }}}
 
 " Set up configurable variables {{{
-let s:default_repository = 'https://github.com/lowski/spaceneovim-layers.git'
+let s:default_repository = 'https://github.com/Tehnix/spaceneovim-layers.git'
 let g:dotspaceneovim_layers_repository = get(g:, 'dotspaceneovim_layers_repository', s:default_repository)
 let g:dotspaceneovim_additional_plugins = get(g:, 'dotspaceneovim_additional_plugins', [])
 let g:dotspaceneovim_configuration_layers = get(g:, 'dotspaceneovim_configuration_layers', [])


### PR DESCRIPTION
This fixes #7 and #15 by introducing `postinstall` phase (after all plugins are loaded by `vim-plug`) and rename current `postinstall` to `postinit` (it's more appropriate since it was evaluated on `VimEnter` which is the last init phase).

I also added PR for layers repo.