### PR TITLE
ignore autogenerated files and dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+autoload/plug.vim
+init.vim
+plugged/
+spaceneovim-layers/


### PR DESCRIPTION
Adding these to the .gitignore will help those with forks keep their working dir clean since these files are autogenerated anyways.