### PR TITLE
Change `timeoutlen` to more sensible value

### DIFF
--- a/vimrc.sample
+++ b/vimrc.sample
@@ -48,7 +48,7 @@
   " Map the leader key to <Space>
   let g:mapleader = ' '
   " Shorten the time before the vim-leader-guide buffer appears
-  set timeoutlen=100
+  set timeoutlen=400
   " Enable line numbers
   " Set 7 lines to the cursor - when moving vertically using j/k
   set scrolloff=7


### PR DESCRIPTION
I know it will introduce delay for showing leader guide but if this settings is set to `100` other plugins like `vim-commentary` or `vim-surround` don't work. It was reported in #19.